### PR TITLE
add prebuild-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ sudo: false
 
 language: node_js
 
-env:
-  - CXX=g++-4.8
-
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,12 @@ addons:
       - g++-4.8
 
 before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX=g++-4.8; fi
   - export JOBS=max
-  - export prebuild_compile=true
+
+os:
+  - osx
+  - linux
 
 node_js:
   - "8"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "node-uuid": "~1.4.3",
     "optimist": "~0.6.1",
     "prebuild": "^6.2.1",
+    "prebuild-ci": "^2.2.3",
     "readfiletree": "~0.0.1",
     "rimraf": "~2.6.1",
     "slump": "~2.0.0",
@@ -49,7 +50,7 @@
   },
   "scripts": {
     "install": "prebuild-install || node-gyp rebuild",
-    "test": "tape test/*-test.js | faucet",
+    "test": "(tape test/*-test.js | faucet) && prebuild-ci",
     "rebuild": "node-gyp rebuild",
     "prebuild": "prebuild --all --verbose --strip"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "leveldown-hyper",
   "description": "A Node.js LevelDB binding, primary backend for LevelUP (HyperDex fork)",
-  "version": "1.1.2",
+  "version": "1.1.3-0",
   "contributors": [
     "Rod Vagg <r@va.gg> (https://github.com/rvagg)",
     "John Chesley <john@chesl.es> (https://github.com/chesles/)",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "bindings": "~1.3.0",
     "fast-future": "~1.0.0",
     "nan": "^2.6.2",
-    "prebuild": "^6.2.1"
+    "prebuild-install": "^2.2.2"
   },
   "devDependencies": {
     "du": "~0.1.0",
@@ -41,15 +41,16 @@
     "monotonic-timestamp": "~0.0.8",
     "node-uuid": "~1.4.3",
     "optimist": "~0.6.1",
+    "prebuild": "^6.2.1",
     "readfiletree": "~0.0.1",
     "rimraf": "~2.6.1",
     "slump": "~2.0.0",
     "tape": "~4.8.0"
   },
   "scripts": {
-    "install": "prebuild --install",
+    "install": "prebuild-install || node-gyp rebuild",
     "test": "tape test/*-test.js | faucet",
-    "rebuild": "prebuild --compile",
+    "rebuild": "node-gyp rebuild",
     "prebuild": "prebuild --all --verbose --strip"
   },
   "license": "MIT",


### PR DESCRIPTION
Closes https://github.com/Level/leveldown-hyper/issues/25

I've created a pre-patch release to test it, see https://github.com/Level/leveldown-hyper/releases/tag/v1.1.3-0 for results

So we have prebuilts for electron, osx and linux now